### PR TITLE
feat: implement multi network contract store

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -30,6 +30,10 @@ jobs:
       - run: npm run build
       - run: npm test
       - run: npm run test:cover
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
   publish:
     runs-on: ubuntu-latest
     name: Versionning and Publish

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Contract Store
 
+[![Coverage Status](https://coveralls.io/repos/github/VGLoic/contract-store/badge.svg?branch=alpha)](https://coveralls.io/github/VGLoic/contract-store?branch=alpha)
+
 **:warning: The package is quite recent, any contributions, issues or feedbacks are welcome :warning:**
 
 Minimalist store in order to manage the various ABIs and deployed contract addresses on multiple networks.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **:warning: The package is quite recent, any contributions, issues or feedbacks are welcome :warning:**
 
-## Get started
+Minimalist store in order to manage the various ABIs and deployed contract addresses on multiple networks.
+
+## Quick start
 
 The recommended way to use Contract-Store with an application is to install it as a dependency:
 
@@ -17,32 +19,178 @@ yarn add contract-store@alpha --dev
 
 Then, one can start storing and using the needed **ABIs** or **deployments**
 ```ts
-import { ContractStore } from 'contract-store';
+import { MultiNetworkContractStore } from 'contract-store';
 
-// Store is for Mainnet wich chain ID 1
-const store = new ContractStore(1);
+const networks = {
+  mainnet: 1,
+  goerli: 5,
+};
+// Store is registered for Mainnet and Goerli
+const store = new MultiNetworkContractStore([
+    networks.mainnet,
+    networks.goerli
+]);
 
 const MY_ABI = [...];
-// Register the ABI and the deployment at key 'FOO'
-store.registerContract('FOO', {
+// Register the ABI and the deployment at key 'FOO' on Mainnet network
+store.registerContract(networks.mainnet, 'FOO', {
     address: '0xCe6afb858673550635b49F8Ffb855b20334228dF',
     abi: MY_ABI
 });
 
-// Register a deployment at key 'BAR' with the default ERC20 ABI
-store.registerDeployment('BAR', {
+...
+
+// ABI and deployment address can then be retrieved anywhere
+const myContractArtifacts = store.getContract(networks.mainnet, 'FOO');
+// `buildContract` is an arbitrary function used as an example here
+const myContract = buildContract(
+    myContractArtifacts.address,
+    myContractArtifacts.abi
+);
+```
+
+## Default ABIs
+
+The contract store already comes with registered ABIs `ERC20`, `ERC721` and `ERC1155` standard ABIs. The ABIs have been generated using [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts) implementations.
+
+```ts
+import { MultiNetworkContractStore } from 'contract-store';
+
+const networks = { goerli: 5 };
+const store = new MultiNetworkContractStore([
+    networks.goerli
+]);
+
+// Register a deployment at key 'BAR' with the default ERC20 ABI on Goerli network
+store.registerDeployment(networks.goerli, 'BAR', {
     address: '0x5A22EA0DC6553267bDB273eB55Ccb40EFA78F804',
     // ERC20, ERC721 and ERC1155 abis are by default included in the store
     abiKey: 'ERC20'
 });
 
 ...
-// ABI and deployment address can then be retrieved anywhere
-const tokenArtifacts = store.getContract('BAR');
-const token = buildContract(tokenArtifacts.address, tokenArtifacts.abi);
 
-const myContractArtifacts = store.getContract('FOO');
-const myContract = buildContract(myContractArtifacts.address, myContractArtifacts.abi);
+// ABI and deployment address can then be retrieved anywhere
+const tokenArtifacts = store.getContract(networks.goerli, 'BAR');
+// `buildContract` is an arbitrary function used as an example here
+const token = buildContract(tokenArtifacts.address, tokenArtifacts.abi);
+```
+
+## API overview
+
+The `MultiNetworkContractStore` methods are organised around two distinct pieces of a contract, the ABI and address.
+
+The ABI is meaningful by itself, while an address is necessarily linked to one ABI underneath. 
+
+For this reason, the `ABIs` and the `deployments` have different methods.
+
+
+### Key value store
+
+Each data stored is organised by a **string key** defined by the developer at insertion. This key is then used in order to retrieve the data.
+
+### One sub store per network
+
+The networks are decoupled from each other, meaning that registering ABIs or deployments on a network will not make them accessible from another network. For this reason, most methods take the `chain ID` of the network as first argument.
+
+### ABI
+
+ABIs can be registered, added or deleted from any configured network.
+```ts
+// Register an ABI on Goerli, it will be available only for Goerli
+store.registerAbi(network.goerli, "FOO", MY_ABI);
+const abi = store.getAbi(networks.goerli, "FOO");
+// Retrieving it on another network will throw
+const thisWillFail = store.getAbi(networks.mainnet, "FOO");
+```
+
+Some ABI deserves to be available on every networks, for this reason, the global ABIs have been introduced. A global ABI is the same on every network and can be registerred, updated or deleted using dedicated methods
+```ts
+// Register an ABI globally, it will be available for every configured networks in the store
+store.registerGlobalAbi("FOO", MY_ABI);
+// One can retrieve it without specifying a network
+const globalAbi = store.getGlobalAbi("FOO");
+// Or by targeting a specific network
+const abi = store.getAbi(networks.goerli, "FOO");
+// It can then be used for any deploymment
+store.registerDeployment(networks.goerli, "BAR", {
+    abiKey: "FOO",
+    address: "0x1234...5678"
+});
+```
+
+### Deployment
+
+A deployment is defined as an Ethereum address linked to an ABI string key.
+
+When the ABI is already registered in the contract, one can register a deployment as
+```ts
+// The ABI with key "FOO" has already been registered on Goerli
+store.registerDeployment(networks.goerli, "BAR", {
+    abiKey: "FOO"
+    address: "0x1234...5678"
+});
+```
+
+If the ABI has not already been registered, one can register at the same time the ABI and the deployment
+```ts
+// The ABI and the deployment will be both registered using the same key "BAR"
+store.registerContract(networks.goerli, "BAR", {
+    abi: MY_ABI,
+    address: "0x1234...5678"
+});
+```
+
+Once a deployment has been registered, one can retrieve the full contract or just the address using the deployment key
+```ts
+// Only the address is retrieved
+const address = store.getAddress(networks.goerli, "BAR");
+// Retrieve both the address and the ABI, even if the ABI is using another key than "BAR"
+const contract = store.getContract(networks.goerli, "BAR");
+```
+
+One can also retrieve all the addresses deployed on a network
+```ts
+// Array of deployed addresses
+const addresses = store.getAddresses(networks.goerli);
+```
+
+## Networks
+
+The `MultiNetworkContractStore` is configured for an initial list of networks from an array of chain IDs given in the constructor. It is then possible to manage the networks using the API exposed by the store.
+
+One can add a network
+```ts
+store.addNetwork(networks.polygon);
+```
+
+Or removing one
+```ts
+store.removeNetwork(networks.polygon);
+```
+
+Here is non exhaustive list of networks and their chain IDs
+```ts
+const networks = {
+  mainnet: 1, // 0x1
+  // Test nets
+  goerli: 5, // 0x5
+  ropsten: 3, // 0x3
+  rinkeby: 4, // 0x4
+  kovan: 42, // 42 0x2a
+  mumbai: 80001, // 0x13881
+  // Layers 2
+  arbitrum: 42161, // 0xa4b1
+  optimism: 10, // 0xa
+  // Side chains
+  polygon: 137, // 0x89
+  gnosisChain: 100, // 0x64
+  // Alt layer 1
+  binanceSmartChain: 56, // 0x38
+  avalanche: 43114, // 0xa86a
+  cronos: 25, // 0x19
+  fantom: 250 // 0xfa
+}
 ```
 
 ## Contributing :rocket:

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-hooks": "^4.2.0",
+        "eslint-plugin-testing-library": "^3.10.1",
         "husky": "^4.3.7",
         "lint-staged": "^10.5.3",
         "prettier": "^2.2.1",
@@ -3824,6 +3825,126 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.10.2.tgz",
+      "integrity": "sha512-WAmOCt7EbF1XM8XfbCKAEzAPnShkNSwcIsAD2jHdsMUT9mZJPjLCG7pMzbcC8kK366NOuGip8HKLDC+Xk4yIdA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^3.10.1"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": "^5 || ^6 || ^7"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/experimental-utils": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz",
+      "integrity": "sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/typescript-estree": "3.10.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/types": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.10.1.tgz",
+      "integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
+      "dev": true,
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz",
+      "integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/visitor-keys": "3.10.1",
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz",
+      "integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/eslint-scope": {
@@ -13987,6 +14108,7 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
       "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -17111,6 +17233,76 @@
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-plugin-testing-library": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.10.2.tgz",
+      "integrity": "sha512-WAmOCt7EbF1XM8XfbCKAEzAPnShkNSwcIsAD2jHdsMUT9mZJPjLCG7pMzbcC8kK366NOuGip8HKLDC+Xk4yIdA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^3.10.1"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz",
+          "integrity": "sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/types": "3.10.1",
+            "@typescript-eslint/typescript-estree": "3.10.1",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^2.0.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.10.1.tgz",
+          "integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz",
+          "integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "3.10.1",
+            "@typescript-eslint/visitor-keys": "3.10.1",
+            "debug": "^4.1.1",
+            "glob": "^7.1.6",
+            "is-glob": "^4.0.1",
+            "lodash": "^4.17.15",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz",
+          "integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -24540,6 +24732,7 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
       "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contract-store",
   "version": "0.0.1-semantic-release",
-  "description": "A contract store for managing ABIs and deployment addresses.",
+  "description": "Minimalist store in order to manage the various ABIs and deployed contract addresses on multiple networks.",
   "keywords": [
     "ethereum",
     "eth",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.25.1",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-testing-library": "^3.10.1",
     "husky": "^4.3.7",
     "lint-staged": "^10.5.3",
     "prettier": "^2.2.1",

--- a/src/__tests__/contract-store.test.ts
+++ b/src/__tests__/contract-store.test.ts
@@ -3,7 +3,6 @@ import ERC20 from "../default-abis/erc20.json";
 import ERC721 from "../default-abis/erc721.json";
 import ERC1155 from "../default-abis/erc1155.json";
 
-
 describe("Contract Store", () => {
   const testAbi = [
     {
@@ -32,7 +31,7 @@ describe("Contract Store", () => {
       type: "event",
     },
   ];
-  
+
   const otherTestAbi = [
     ...testAbi,
     {
@@ -81,32 +80,32 @@ describe("Contract Store", () => {
   describe("ABI management", () => {
     test("it should allow to register, update and delete an ABI", () => {
       const store = new ContractStore(1);
-  
+
       store.registerAbi("FOO", testAbi);
       expect(store.getAbi("FOO")).toEqual(testAbi);
-  
+
       store.updateAbi("FOO", otherTestAbi);
-  
+
       expect(store.getAbi("FOO")).toEqual(otherTestAbi);
-  
+
       store.deleteAbi("FOO");
-  
+
       expect(() => store.getAbi("FOO")).toThrow();
     });
-  
+
     test("it should not allow to register an ABI under an already used key", () => {
       const store = new ContractStore(1);
       store.registerAbi("FOO", testAbi);
       expect(store.getAbi("FOO")).toEqual(testAbi);
-  
+
       expect(() => store.registerAbi("FOO", otherTestAbi)).toThrow();
     });
-  
+
     test("it should not allow to update an ABI if it is not registered", () => {
       const store = new ContractStore(1);
       expect(() => store.updateAbi("FOO", otherTestAbi)).toThrow();
     });
-  
+
     test("it should not allow to delete an ABI if it is used in a deployment", () => {
       const store = new ContractStore(1);
       store.registerContract("FOO", {
@@ -115,27 +114,27 @@ describe("Contract Store", () => {
       });
       expect(() => store.deleteAbi("FOO")).toThrow();
     });
-  })
+  });
 
   describe("deployment management", () => {
     test("it should allow to register, update, and delete a deployment using an existing ABI", () => {
       const store = new ContractStore(1);
-      
+
       store.registerDeployment("FOO", {
         address,
-        abiKey: "ERC20"
+        abiKey: "ERC20",
       });
       expect(store.getAddress("FOO")).toEqual(address);
       expect(store.getContract("FOO")).toEqual({
         address,
-        abi: ERC20
+        abi: ERC20,
       });
 
-      store.updateDeployment('FOO', "ERC721");
+      store.updateDeployment("FOO", "ERC721");
       expect(store.getAddress("FOO")).toEqual(address);
       expect(store.getContract("FOO")).toEqual({
         address,
-        abi: ERC721
+        abi: ERC721,
       });
 
       store.deleteDeployment("FOO");
@@ -145,39 +144,43 @@ describe("Contract Store", () => {
 
     test("it should allow to register an ABI and a deployment at once", () => {
       const store = new ContractStore(1);
-      
+
       store.registerContract("FOO", {
         address,
-        abi: testAbi
+        abi: testAbi,
       });
       expect(store.getAddress("FOO")).toEqual(address);
       expect(store.getAbi("FOO")).toEqual(testAbi);
       expect(store.getContract("FOO")).toEqual({
         address,
-        abi: testAbi
+        abi: testAbi,
       });
     });
 
     test("it should not allow to register a deployment with an already used key", () => {
       const store = new ContractStore(1);
-      
+
       store.registerDeployment("FOO", {
         address,
-        abiKey: "ERC20"
+        abiKey: "ERC20",
       });
-      expect(() => store.registerDeployment('FOO', {
-        address,
-        abiKey: 'ERC721'
-      })).toThrow();
+      expect(() =>
+        store.registerDeployment("FOO", {
+          address,
+          abiKey: "ERC721",
+        })
+      ).toThrow();
     });
 
     test("it should not allow to register a deployment with an unknown ABI key", () => {
       const store = new ContractStore(1);
-      
-      expect(() => store.registerDeployment('FOO', {
-        address,
-        abiKey: 'unknown'
-      })).toThrow();
+
+      expect(() =>
+        store.registerDeployment("FOO", {
+          address,
+          abiKey: "unknown",
+        })
+      ).toThrow();
     });
 
     test("it should not allow to update a deployment with an unknown ABI key", () => {
@@ -185,17 +188,16 @@ describe("Contract Store", () => {
 
       store.registerDeployment("FOO", {
         address,
-        abiKey: "ERC20"
+        abiKey: "ERC20",
       });
-      
-      expect(() => store.updateDeployment('FOO', 'unknown')).toThrow();
+
+      expect(() => store.updateDeployment("FOO", "unknown")).toThrow();
     });
 
     test("it should not allow to update an unknown deployment", () => {
       const store = new ContractStore(1);
-      
-      expect(() => store.updateDeployment('FOO', 'ERC20')).toThrow();
+
+      expect(() => store.updateDeployment("FOO", "ERC20")).toThrow();
     });
   });
-
 });

--- a/src/__tests__/contract-store.test.ts
+++ b/src/__tests__/contract-store.test.ts
@@ -199,5 +199,16 @@ describe("Contract Store", () => {
 
       expect(() => store.updateDeployment("FOO", "ERC20")).toThrow();
     });
+
+    test("it should allow to retrieve the deployments addresses", () => {
+      const store = new ContractStore(1);
+
+      store.registerDeployment("FOO", {
+        address,
+        abiKey: "ERC20",
+      });
+
+      expect(store.getAddresses()).toEqual([address]);
+    });
   });
 });

--- a/src/__tests__/multi-network-contract-store.test.ts
+++ b/src/__tests__/multi-network-contract-store.test.ts
@@ -1,0 +1,120 @@
+import { MultiNetworkContractStore } from "../multi-network-contract-store";
+import ERC20 from "../default-abis/erc20.json";
+import ERC721 from "../default-abis/erc721.json";
+import ERC1155 from "../default-abis/erc1155.json";
+
+describe("Multi network contract store", () => {
+  // const testAbi = [
+  //     {
+  //       anonymous: false,
+  //       inputs: [
+  //         {
+  //           indexed: true,
+  //           internalType: "address",
+  //           name: "owner",
+  //           type: "address",
+  //         },
+  //         {
+  //           indexed: true,
+  //           internalType: "address",
+  //           name: "spender",
+  //           type: "address",
+  //         },
+  //         {
+  //           indexed: false,
+  //           internalType: "uint256",
+  //           name: "value",
+  //           type: "uint256",
+  //         },
+  //       ],
+  //       name: "Approval",
+  //       type: "event",
+  //     },
+  //   ];
+
+  // const otherTestAbi = [
+  //   ...testAbi,
+  //   {
+  //     anonymous: false,
+  //     inputs: [
+  //       {
+  //         indexed: true,
+  //         internalType: "address",
+  //         name: "owner",
+  //         type: "address",
+  //       },
+  //       {
+  //         indexed: true,
+  //         internalType: "address",
+  //         name: "operator",
+  //         type: "address",
+  //       },
+  //       {
+  //         indexed: false,
+  //         internalType: "bool",
+  //         name: "approved",
+  //         type: "bool",
+  //       },
+  //     ],
+  //     name: "ApprovalForAll",
+  //     type: "event",
+  //   },
+  // ];
+  // const address = "0x65056df4226b218A79C9473189FC5Ec7D41D8198";
+
+  const chainIds = [1, 2];
+
+  test("it should contain the default abis as global ABI if not explictly written in the options", () => {
+    const store = new MultiNetworkContractStore(chainIds);
+
+    for (const chainId of chainIds) {
+      expect(store.getAbi(chainId, "ERC20")).toEqual(ERC20);
+      expect(store.getAbi(chainId, "ERC721")).toEqual(ERC721);
+      expect(store.getAbi(chainId, "ERC1155")).toEqual(ERC1155);
+    }
+
+    expect(store.getGlobalAbi("ERC20")).toEqual(ERC20);
+    expect(store.getGlobalAbi("ERC721")).toEqual(ERC721);
+    expect(store.getGlobalAbi("ERC1155")).toEqual(ERC1155);
+  });
+
+  test("it should not contain the default ABIs if specified in the options", () => {
+    const store = new MultiNetworkContractStore(chainIds, {
+      withoutDefaultABIs: true,
+    });
+    for (const chainId of chainIds) {
+      expect(() => store.getAbi(chainId, "ERC20")).toThrow();
+      expect(() => store.getAbi(chainId, "ERC721")).toThrow();
+      expect(() => store.getAbi(chainId, "ERC1155")).toThrow();
+    }
+    expect(() => store.getGlobalAbi("ERC20")).toThrow();
+    expect(() => store.getGlobalAbi("ERC721")).toThrow();
+    expect(() => store.getGlobalAbi("ERC1155")).toThrow();
+  });
+
+  test("`gerChainIds` should return the list of chain IDs", () => {
+    const store = new MultiNetworkContractStore(chainIds);
+    expect(store.getChainIds()).toEqual(chainIds);
+  });
+
+  test("`addNetwork` should add the chain ID with the global ABIs", () => {
+    const store = new MultiNetworkContractStore(chainIds);
+
+    store.addNetwork(3);
+    expect(store.getAbi(3, "ERC20")).toEqual(ERC20);
+    expect(store.getAbi(3, "ERC721")).toEqual(ERC721);
+    expect(store.getAbi(3, "ERC1155")).toEqual(ERC1155);
+  });
+
+  test("`addNetwork` should throw if the network is already configured", () => {
+    const store = new MultiNetworkContractStore(chainIds);
+    expect(() => store.addNetwork(2)).toThrow();
+  });
+
+  test("`removeNetwork` should delete the store associated to the chain ID", () => {
+    const store = new MultiNetworkContractStore(chainIds);
+    store.removeNetwork(1);
+    expect(() => store.getAbi(1, "ERC20")).toThrow();
+    expect(store.getChainIds()).toEqual([2]);
+  });
+});

--- a/src/__tests__/multi-network-contract-store.test.ts
+++ b/src/__tests__/multi-network-contract-store.test.ts
@@ -4,117 +4,318 @@ import ERC721 from "../default-abis/erc721.json";
 import ERC1155 from "../default-abis/erc1155.json";
 
 describe("Multi network contract store", () => {
-  // const testAbi = [
-  //     {
-  //       anonymous: false,
-  //       inputs: [
-  //         {
-  //           indexed: true,
-  //           internalType: "address",
-  //           name: "owner",
-  //           type: "address",
-  //         },
-  //         {
-  //           indexed: true,
-  //           internalType: "address",
-  //           name: "spender",
-  //           type: "address",
-  //         },
-  //         {
-  //           indexed: false,
-  //           internalType: "uint256",
-  //           name: "value",
-  //           type: "uint256",
-  //         },
-  //       ],
-  //       name: "Approval",
-  //       type: "event",
-  //     },
-  //   ];
+  const testAbi = [
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "owner",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "spender",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "uint256",
+          name: "value",
+          type: "uint256",
+        },
+      ],
+      name: "Approval",
+      type: "event",
+    },
+  ];
 
-  // const otherTestAbi = [
-  //   ...testAbi,
-  //   {
-  //     anonymous: false,
-  //     inputs: [
-  //       {
-  //         indexed: true,
-  //         internalType: "address",
-  //         name: "owner",
-  //         type: "address",
-  //       },
-  //       {
-  //         indexed: true,
-  //         internalType: "address",
-  //         name: "operator",
-  //         type: "address",
-  //       },
-  //       {
-  //         indexed: false,
-  //         internalType: "bool",
-  //         name: "approved",
-  //         type: "bool",
-  //       },
-  //     ],
-  //     name: "ApprovalForAll",
-  //     type: "event",
-  //   },
-  // ];
-  // const address = "0x65056df4226b218A79C9473189FC5Ec7D41D8198";
+  const otherTestAbi = [
+    ...testAbi,
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "owner",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "operator",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "bool",
+          name: "approved",
+          type: "bool",
+        },
+      ],
+      name: "ApprovalForAll",
+      type: "event",
+    },
+  ];
+  const address = "0x65056df4226b218A79C9473189FC5Ec7D41D8198";
 
   const chainIds = [1, 2];
 
-  test("it should contain the default abis as global ABI if not explictly written in the options", () => {
-    const store = new MultiNetworkContractStore(chainIds);
+  describe("network management", () => {
+    test("it should contain the default abis as global ABI if not explictly written in the options", () => {
+      const store = new MultiNetworkContractStore(chainIds);
 
-    for (const chainId of chainIds) {
-      expect(store.getAbi(chainId, "ERC20")).toEqual(ERC20);
-      expect(store.getAbi(chainId, "ERC721")).toEqual(ERC721);
-      expect(store.getAbi(chainId, "ERC1155")).toEqual(ERC1155);
-    }
+      for (const chainId of chainIds) {
+        expect(store.getAbi(chainId, "ERC20")).toEqual(ERC20);
+        expect(store.getAbi(chainId, "ERC721")).toEqual(ERC721);
+        expect(store.getAbi(chainId, "ERC1155")).toEqual(ERC1155);
+      }
 
-    expect(store.getGlobalAbi("ERC20")).toEqual(ERC20);
-    expect(store.getGlobalAbi("ERC721")).toEqual(ERC721);
-    expect(store.getGlobalAbi("ERC1155")).toEqual(ERC1155);
-  });
-
-  test("it should not contain the default ABIs if specified in the options", () => {
-    const store = new MultiNetworkContractStore(chainIds, {
-      withoutDefaultABIs: true,
+      expect(store.getGlobalAbi("ERC20")).toEqual(ERC20);
+      expect(store.getGlobalAbi("ERC721")).toEqual(ERC721);
+      expect(store.getGlobalAbi("ERC1155")).toEqual(ERC1155);
     });
-    for (const chainId of chainIds) {
-      expect(() => store.getAbi(chainId, "ERC20")).toThrow();
-      expect(() => store.getAbi(chainId, "ERC721")).toThrow();
-      expect(() => store.getAbi(chainId, "ERC1155")).toThrow();
-    }
-    expect(() => store.getGlobalAbi("ERC20")).toThrow();
-    expect(() => store.getGlobalAbi("ERC721")).toThrow();
-    expect(() => store.getGlobalAbi("ERC1155")).toThrow();
+
+    test("it should not contain the default ABIs if specified in the options", () => {
+      const store = new MultiNetworkContractStore(chainIds, {
+        withoutDefaultABIs: true,
+      });
+      for (const chainId of chainIds) {
+        expect(() => store.getAbi(chainId, "ERC20")).toThrow();
+        expect(() => store.getAbi(chainId, "ERC721")).toThrow();
+        expect(() => store.getAbi(chainId, "ERC1155")).toThrow();
+      }
+      expect(() => store.getGlobalAbi("ERC20")).toThrow();
+      expect(() => store.getGlobalAbi("ERC721")).toThrow();
+      expect(() => store.getGlobalAbi("ERC1155")).toThrow();
+    });
+
+    test("`gerChainIds` should return the list of chain IDs", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      expect(store.getChainIds()).toEqual(chainIds);
+    });
+
+    test("`addNetwork` should add the chain ID with the global ABIs", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+
+      store.addNetwork(3);
+      expect(store.getAbi(3, "ERC20")).toEqual(ERC20);
+      expect(store.getAbi(3, "ERC721")).toEqual(ERC721);
+      expect(store.getAbi(3, "ERC1155")).toEqual(ERC1155);
+    });
+
+    test("`addNetwork` should throw if the network is already configured", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      expect(() => store.addNetwork(2)).toThrow();
+    });
+
+    test("`removeNetwork` should delete the store associated to the chain ID", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.removeNetwork(1);
+      expect(() => store.getAbi(1, "ERC20")).toThrow();
+      expect(store.getChainIds()).toEqual([2]);
+    });
+
+    test("`removeNetwork` should throw if the network is not registered", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      expect(() => store.removeNetwork(24324234)).toThrow();
+    });
   });
 
-  test("`gerChainIds` should return the list of chain IDs", () => {
-    const store = new MultiNetworkContractStore(chainIds);
-    expect(store.getChainIds()).toEqual(chainIds);
+  describe("ABI management", () => {
+    test("`registerGlobalAbi` should register the ABI on every networks", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.registerGlobalAbi("FOO", testAbi);
+
+      expect(store.getGlobalAbi("FOO")).toEqual(testAbi);
+      chainIds.forEach((chainId) => {
+        expect(store.getAbi(chainId, "FOO")).toEqual(testAbi);
+      });
+    });
+
+    test("`registerGlobalAbi` should throw if a global ABI with the same key exist", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.registerGlobalAbi("FOO", testAbi);
+
+      expect(() => store.registerGlobalAbi("FOO", otherTestAbi)).toThrow();
+    });
+
+    test("`registerGlobalAbi` should throw if an ABI with the same key exist on a network", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.registerAbi(chainIds[0], "FOO", testAbi);
+
+      expect(() => store.registerGlobalAbi("FOO", otherTestAbi)).toThrow();
+    });
+
+    test("`updateGlobalABI` should update the ABI on every networks", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.registerGlobalAbi("FOO", testAbi);
+
+      store.updateGlobalAbi("FOO", otherTestAbi);
+
+      expect(store.getGlobalAbi("FOO")).toEqual(otherTestAbi);
+      chainIds.forEach((chainId) => {
+        expect(store.getAbi(chainId, "FOO")).toEqual(otherTestAbi);
+      });
+    });
+
+    test("`updateGlobalABI` should throw if the key is not a global ABI", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      expect(() => store.updateGlobalAbi("FOO", otherTestAbi)).toThrow();
+    });
+
+    test("`deleteGlobalAbi` should delete the ABI on every network", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.registerGlobalAbi("FOO", testAbi);
+      store.deleteGlobalAbi("FOO");
+
+      expect(() => store.getGlobalAbi("FOO")).toThrow();
+      chainIds.forEach((chainId) => {
+        expect(() => store.getAbi(chainId, "FOO")).toThrow();
+      });
+    });
+
+    test("`deleteGlobalABI` should throw if the key is not one of a global ABI", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      expect(() => store.deleteGlobalAbi("FOO")).toThrow();
+    });
+
+    test("`deleteGlobalABI` should throw if the ABI is used in a deployment", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.registerGlobalAbi("FOO", testAbi);
+      store.registerDeployement(chainIds[0], "MY_FOO", {
+        abiKey: "FOO",
+        address,
+      });
+
+      expect(() => store.deleteGlobalAbi("FOO")).toThrow();
+    });
+
+    test("`registerAbi` should register the ABI on the proper network", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.registerAbi(chainIds[0], "FOO", testAbi);
+      expect(store.getAbi(chainIds[0], "FOO")).toEqual(testAbi);
+    });
+
+    test("`registerAbi` should throw if the key already exists as global", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.registerGlobalAbi("FOO", testAbi);
+
+      expect(() =>
+        store.registerAbi(chainIds[0], "FOO", otherTestAbi)
+      ).toThrow();
+    });
+
+    test("`updateAbi` should update the ABI on the proper network", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.registerAbi(chainIds[0], "FOO", testAbi);
+      store.updateAbi(chainIds[0], "FOO", otherTestAbi);
+      expect(store.getAbi(chainIds[0], "FOO")).toEqual(otherTestAbi);
+    });
+
+    test("`updateAbi` should throw if the key is associated to a global ABI", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.registerGlobalAbi("FOO", testAbi);
+
+      expect(() => store.updateAbi(chainIds[0], "FOO", otherTestAbi)).toThrow();
+    });
+
+    test("`deleteAbi` should delete the ABI on the proper network", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.registerAbi(chainIds[0], "FOO", testAbi);
+      store.deleteAbi(chainIds[0], "FOO");
+
+      expect(() => store.getAbi(chainIds[0], "FOO")).toThrow();
+    });
+
+    test("`deleteAbi` should throw if the key is associated to a global ABI", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+      store.registerGlobalAbi("FOO", testAbi);
+
+      expect(() => store.deleteAbi(chainIds[0], "FOO")).toThrow();
+    });
   });
 
-  test("`addNetwork` should add the chain ID with the global ABIs", () => {
-    const store = new MultiNetworkContractStore(chainIds);
+  describe("Deployment management", () => {
+    test("`registerDeployment` should register a deployment on the proper network", () => {
+      const store = new MultiNetworkContractStore(chainIds);
 
-    store.addNetwork(3);
-    expect(store.getAbi(3, "ERC20")).toEqual(ERC20);
-    expect(store.getAbi(3, "ERC721")).toEqual(ERC721);
-    expect(store.getAbi(3, "ERC1155")).toEqual(ERC1155);
-  });
+      store.registerDeployement(chainIds[0], "BAR", {
+        abiKey: "ERC20",
+        address,
+      });
 
-  test("`addNetwork` should throw if the network is already configured", () => {
-    const store = new MultiNetworkContractStore(chainIds);
-    expect(() => store.addNetwork(2)).toThrow();
-  });
+      expect(store.getAddress(chainIds[0], "BAR")).toEqual(address);
+      expect(store.getContract(chainIds[0], "BAR")).toEqual({
+        address,
+        abi: store.getGlobalAbi("ERC20"),
+      });
+    });
 
-  test("`removeNetwork` should delete the store associated to the chain ID", () => {
-    const store = new MultiNetworkContractStore(chainIds);
-    store.removeNetwork(1);
-    expect(() => store.getAbi(1, "ERC20")).toThrow();
-    expect(store.getChainIds()).toEqual([2]);
+    test("`registerContract` should register a deployment and an ABI on the proper network", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+
+      store.registerContract(chainIds[0], "BAR", {
+        abi: testAbi,
+        address,
+      });
+
+      expect(store.getAddress(chainIds[0], "BAR")).toEqual(address);
+      expect(store.getAbi(chainIds[0], "BAR")).toEqual(testAbi);
+      expect(store.getContract(chainIds[0], "BAR")).toEqual({
+        address,
+        abi: testAbi,
+      });
+    });
+
+    test("`updateDeployment` should update the deployment on the proper network", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+
+      store.registerDeployement(chainIds[0], "BAR", {
+        abiKey: "ERC20",
+        address,
+      });
+
+      store.updateDeployment(chainIds[0], "BAR", "ERC721");
+
+      expect(store.getAddress(chainIds[0], "BAR")).toEqual(address);
+      expect(store.getContract(chainIds[0], "BAR")).toEqual({
+        address,
+        abi: store.getGlobalAbi("ERC721"),
+      });
+    });
+
+    test("`deleteDeployment` should delete the deployment on the proper network", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+
+      store.registerDeployement(chainIds[0], "BAR", {
+        abiKey: "ERC20",
+        address,
+      });
+
+      store.deleteDeployment(chainIds[0], "BAR");
+
+      expect(() => store.getAddress(chainIds[0], "BAR")).toThrow();
+      expect(() => store.getContract(chainIds[0], "BAR")).toThrow();
+    });
+
+    test("`getAddresses` should get the deployments addresses on the proper network", () => {
+      const store = new MultiNetworkContractStore(chainIds);
+
+      store.registerDeployement(chainIds[0], "FOO", {
+        abiKey: "ERC20",
+        address,
+      });
+
+      const otherAddress = "0xf1d1F31983ffd497519C17f081CFf3B35B2A04b2";
+      store.registerDeployement(chainIds[0], "BAR", {
+        abiKey: "ERC20",
+        address: otherAddress,
+      });
+      expect(store.getAddresses(chainIds[0])).toEqual([address, otherAddress]);
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
+export * from "./ethers-type";
 export * from "./contract-store";
+export * from "./multi-network-contract-store";

--- a/src/multi-network-contract-store.ts
+++ b/src/multi-network-contract-store.ts
@@ -1,0 +1,282 @@
+import EventEmitter from "events";
+import { ABI, Contract, ContractStore, Deployment } from "./contract-store";
+import ERC20 from "./default-abis/erc20.json";
+import ERC721 from "./default-abis/erc721.json";
+import ERC1155 from "./default-abis/erc1155.json";
+
+type MultiNetworkOptions = {
+  withoutDefaultABIs?: boolean;
+};
+
+/**
+ * Contract store for managing ABIs and deployments on multiple networks
+ */
+export class MultiNetworkContractStore extends EventEmitter {
+  private stores: Record<number, ContractStore>;
+  private globalAbis: Record<string, ABI> = {};
+
+  constructor(chainIds: number[], opts?: MultiNetworkOptions) {
+    super();
+    const stores = Array.from(new Set(chainIds)).reduce(
+      (acc, chainId) => ({
+        ...acc,
+        [chainId]: new ContractStore(chainId, { withoutDefaultABIs: true }),
+      }),
+      {} as Record<number, ContractStore>
+    );
+    this.stores = stores;
+    if (!opts?.withoutDefaultABIs) {
+      this.registerGlobalAbi("ERC20", ERC20);
+      this.registerGlobalAbi("ERC721", ERC721);
+      this.registerGlobalAbi("ERC1155", ERC1155);
+    }
+  }
+
+  /**
+   * Get the configured chain IDs
+   * @returns The array of configured chain IDs
+   */
+  public getChainIds() {
+    return Object.keys(this.stores).map(Number);
+  }
+
+  /**
+   * Add a network
+   * @param chainId Chain ID of the network
+   */
+  public addNetwork(chainId: number) {
+    if (this.stores[chainId]) {
+      throw new Error(`Chain ID ${chainId} is already configured.`);
+    }
+    const store = new ContractStore(chainId, { withoutDefaultABIs: true });
+    Object.entries(this.globalAbis).forEach(([key, abi]) => {
+      store.registerAbi(key, abi);
+    });
+    this.stores[chainId] = store;
+
+    this.emit("network/added", { chainId });
+    return this;
+  }
+
+  /**
+   * Remove a network
+   * @param chainId Chain ID of the network
+   */
+  public removeNetwork(chainId: number) {
+    if (!this.stores[chainId]) {
+      throw new Error(`Chain ID ${chainId} is not configured.`);
+    }
+    delete this.stores[chainId];
+
+    this.emit("network/deleted", { chainId });
+    return this;
+  }
+
+  /**
+   * Register a global ABI, replicating in every networks
+   * @param key String key of the ABI
+   * @param abi ABI
+   */
+  public registerGlobalAbi(key: string, abi: ABI) {
+    if (this.globalAbis[key]) {
+      throw new Error(`A global ABI for key ${key} already exists`);
+    }
+    this.globalAbis[key] = abi;
+    Object.values(this.stores).forEach((store) => {
+      store.registerAbi(key, abi);
+    });
+    return this;
+  }
+
+  /**
+   * Update a global ABI, replicate the updates in every networks
+   * @param key String key of the ABI
+   * @param abi ABI
+   */
+  public updateGlobalAbi(key: string, abi: ABI) {
+    if (!this.globalAbis[key]) {
+      throw new Error(`No global ABI for key ${key} has been found.`);
+    }
+    this.globalAbis[key] = abi;
+    Object.values(this.stores).forEach((store) => {
+      store.updateAbi(key, abi);
+    });
+    return this;
+  }
+
+  /**
+   * Delete a global ABI, replicating the delete in every networks
+   * @param key String key of the ABI
+   */
+  public deleteGlobalAbi(key: string) {
+    if (!this.globalAbis[key]) {
+      throw new Error(`No global ABI for key ${key} has been found.`);
+    }
+    const isAbiUsed = Object.values(this.stores)
+      .map((store) => store.isAbiUsed(key))
+      .some((isUsed) => isUsed);
+    if (isAbiUsed) {
+      throw new Error(
+        `Unable to delete the global abi for key ${key} as it is used in at least one deployment`
+      );
+    }
+    Object.values(this.stores).forEach((store) => {
+      store.deleteAbi(key);
+    });
+    delete this.globalAbis[key];
+    return this;
+  }
+
+  /**
+   * Register an ABI
+   * @param chainId Chain ID of the network
+   * @param key String key of the ABI
+   * @param abi ABI
+   */
+  public registerAbi(chainId: number, key: string, abi: ABI) {
+    if (this.globalAbis[key]) {
+      throw new Error(`Key ${key} is already used for a global ABI.`);
+    }
+    this.getStore(chainId).registerAbi(key, abi);
+    return this;
+  }
+
+  /**
+   * Register a deployment
+   * @param chainId Chain ID of the network
+   * @param key String key of the deployment
+   * @param deployment.address Address of the contract
+   * @param deployment.abiKey String key of the already registered ABI
+   */
+  public registerDeployement(
+    chainId: number,
+    key: string,
+    deployment: Deployment
+  ) {
+    this.getStore(chainId).registerDeployment(key, deployment);
+    return this;
+  }
+
+  /**
+   * Register a contract, the ABI and address are stored under the provided key
+   * @param chainId Chain ID of the network
+   * @param key Strink key for the address and ABI
+   * @param contract.address Address of the contract
+   * @param contract.abi ABI of the contract
+   */
+  public registerContract(chainId: number, key: string, contract: Contract) {
+    this.getStore(chainId).registerContract(key, contract);
+    return this;
+  }
+
+  /**
+   * Update an ABI
+   * @param chainId Chain ID of the network
+   * @param key String key of the ABI
+   * @param abi New ABI
+   */
+  public updateAbi(chainId: number, key: string, abi: ABI) {
+    if (this.globalAbis[key]) {
+      throw new Error(
+        `Key ${key} is associated to a global ABI. Please, use 'updateGlobalABI' in order to update it.`
+      );
+    }
+    this.getStore(chainId).updateAbi(key, abi);
+    return this;
+  }
+
+  /**
+   * Update a deployment, only the ABI key can be updated
+   * @param chainId Chain ID of the network
+   * @param key String key of the deployment
+   * @param abiKey The new ABI key of the deployment
+   */
+  public updateDeployment(chainId: number, key: string, abiKey: string) {
+    this.getStore(chainId).updateDeployment(key, abiKey);
+    return this;
+  }
+
+  /**
+   * Delete a deployment
+   * @param chainId Chain ID of the network
+   * @param key String key of the deployment
+   */
+  public deleteDeployment(chainId: number, key: string) {
+    this.getStore(chainId).deleteDeployment(key);
+    return this;
+  }
+
+  /**
+   * Delete an ABI, the ABI can not be currently used in a deployment
+   * @param chainId Chain ID of the network
+   * @param key String key of the ABI
+   */
+  public deleteAbi(chainId: number, key: string) {
+    if (this.globalAbis[key]) {
+      throw new Error(
+        `Key ${key} is associated to a global ABI. Please, use 'deleteGlobalABI' in order to delete it.`
+      );
+    }
+    this.getStore(chainId).deleteAbi(key);
+    return this;
+  }
+
+  /**
+   * Get a global ABI
+   * @param key String key of the ABI
+   * @returns The ABI
+   */
+  public getGlobalAbi(key: string) {
+    if (!this.globalAbis[key]) {
+      throw new Error(`Key ${key} is not associated to a global ABI.`);
+    }
+    return this.globalAbis[key];
+  }
+
+  /**
+   * Get an ABI
+   * @param chainId Chain ID of the network
+   * @param key String key of the ABI
+   * @returns The ABI
+   */
+  public getAbi(chainId: number, key: string) {
+    return this.getStore(chainId).getAbi(key);
+  }
+
+  /**
+   * Get a contract by finding the address and ABI
+   * @param chainId Chain ID of the network
+   * @param key String key of the deployment of the contract
+   * @returns The address and ABI of the contract
+   */
+  public getContract(chainId: number, key: string) {
+    return this.getStore(chainId).getContract(key);
+  }
+
+  /**
+   * Get an address
+   * @param chainId Chain ID of the network
+   * @param key String key of the deployment
+   * @returns The address of the deployment
+   */
+  public getAddress(chainId: number, key: string) {
+    return this.getStore(chainId).getAddress(key);
+  }
+
+  /**
+   * Get all the addresses
+   * @param chainId Chain ID of the network
+   * @returns The array of addresses
+   */
+  public getAddresses(chainId: number) {
+    return this.getStore(chainId).getAddresses();
+  }
+
+  private getStore(chainId: number) {
+    const store = this.stores[chainId];
+    if (!store) {
+      throw new Error(`Chain ID ${chainId} is not configured.`);
+    }
+    return store;
+  }
+}


### PR DESCRIPTION
## Summary

The multi network contract store has been implemented, it is a collection of Contract store per network. Additionally, it allows to globally register ABI for all the networks.

Additional modifications:
- setter methods in Contract store now returns the instance of the contract store and are no longer void