### PR TITLE
feat: add object export method

### DIFF
--- a/src/multi-network/dynamic-multi-network-contract-store.test.ts
+++ b/src/multi-network/dynamic-multi-network-contract-store.test.ts
@@ -116,6 +116,46 @@ describe("Multi network contract store", () => {
         address,
         abi: otherTestAbi,
       });
+      expect(store.toObject()).toEqual({
+        globalAbis: {
+          GLOB: testAbi,
+          ERC20,
+          ERC721,
+          ERC1155,
+        },
+        networks: {
+          1: {
+            abis: {
+              FOO: testAbi,
+              GLOB: testAbi,
+              ERC20,
+              ERC721,
+              ERC1155,
+            },
+            deployments: {
+              BAR: {
+                abiKey: "ERC20",
+                address,
+              },
+            },
+          },
+          2: {
+            abis: {
+              FOO2: otherTestAbi,
+              GLOB: testAbi,
+              ERC20,
+              ERC721,
+              ERC1155,
+            },
+            deployments: {
+              BAR2: {
+                abiKey: "FOO2",
+                address,
+              },
+            },
+          },
+        },
+      });
     });
   });
 

--- a/src/multi-network/dynamic-multi-network-contract-store.ts
+++ b/src/multi-network/dynamic-multi-network-contract-store.ts
@@ -406,6 +406,21 @@ export class DynamicContractStore<
     return this.getStore(chainId).getAddresses();
   }
 
+  /**
+   * Convert the store to an object
+   * @returns The store abis and deployments by networks with the global abis
+   */
+  public toObject() {
+    const chainIds = this.getChainIds();
+    return {
+      globalAbis: this.globalAbis,
+      networks: chainIds.reduce((acc, chainId) => {
+        acc[chainId] = this.getStore(chainId).toObject();
+        return acc;
+      }, {} as Record<number, Network>),
+    };
+  }
+
   private getStore<ChainId extends OriginalChainId<OriginalConfig>>(
     chainId: NumericUnion<ChainId>
   ) {

--- a/src/multi-network/multi-network-contract-store.test.ts
+++ b/src/multi-network/multi-network-contract-store.test.ts
@@ -123,6 +123,46 @@ describe("Dynamic Multi network contract store", () => {
       });
       expect(store.getAddress(2, "BAR2")).toEqual(address);
       expect(() => store.getAddresses(3 as 1)).toThrow();
+      expect(store.toObject()).toEqual({
+        globalAbis: {
+          GLOB: testAbi,
+          ERC20,
+          ERC721,
+          ERC1155,
+        },
+        networks: {
+          1: {
+            abis: {
+              FOO: testAbi,
+              GLOB: testAbi,
+              ERC20,
+              ERC721,
+              ERC1155,
+            },
+            deployments: {
+              BAR: {
+                abiKey: "ERC20",
+                address,
+              },
+            },
+          },
+          2: {
+            abis: {
+              FOO2: otherTestAbi,
+              GLOB: testAbi,
+              ERC20,
+              ERC721,
+              ERC1155,
+            },
+            deployments: {
+              BAR2: {
+                abiKey: "FOO2",
+                address,
+              },
+            },
+          },
+        },
+      });
     });
 
     test("it should not include the default ABIs if specified", () => {

--- a/src/multi-network/multi-network-contract-store.ts
+++ b/src/multi-network/multi-network-contract-store.ts
@@ -123,7 +123,7 @@ export class ContractStore<
    * @returns The array of configured chain IDs
    */
   public getChainIds() {
-    return Object.keys(this.stores).map(Number);
+    return Object.keys(this.stores).map(Number) as AllowedChainId<Networks>[];
   }
 
   /**
@@ -184,6 +184,21 @@ export class ContractStore<
    */
   public getAddresses(chainId: AllowedChainId<Networks>) {
     return this.getStore(chainId).getAddresses();
+  }
+
+  /**
+   * Convert the store to an object
+   * @returns The store abis and deployments by networks with the global abis
+   */
+  public toObject() {
+    const chainIds = this.getChainIds();
+    return {
+      globalAbis: this.globalAbis,
+      networks: chainIds.reduce((acc, chainId) => {
+        acc[chainId] = this.getStore(chainId).toObject();
+        return acc;
+      }, {} as Record<AllowedChainId<Networks>, Network>),
+    };
   }
 
   private getStore(chainId: AllowedChainId<Networks>) {

--- a/src/single-network/dynamic-single-network-contract-store.test.ts
+++ b/src/single-network/dynamic-single-network-contract-store.test.ts
@@ -83,6 +83,21 @@ describe("Dynamic Single Network Contract Store", () => {
         address,
         abi: ERC20,
       });
+
+      expect(store.toObject()).toEqual({
+        abis: {
+          FOO: testAbi,
+          ERC20,
+          ERC721,
+          ERC1155,
+        },
+        deployments: {
+          BAR: {
+            abiKey: "ERC20",
+            address,
+          },
+        },
+      });
     });
   });
 

--- a/src/single-network/dynamic-single-network-contract-store.ts
+++ b/src/single-network/dynamic-single-network-contract-store.ts
@@ -268,6 +268,17 @@ export class DynamicSingleNetworkContractStore<
   }
 
   /**
+   * Convert the store to an object
+   * @returns The store abis and deployments
+   */
+  public toObject() {
+    return {
+      abis: this.abis,
+      deployments: this.deployments,
+    };
+  }
+
+  /**
    * Get a deployment
    * @param key String key of the deployment
    * @returns The deployment

--- a/src/single-network/single-network-contract-store.test.ts
+++ b/src/single-network/single-network-contract-store.test.ts
@@ -56,6 +56,21 @@ describe("Static Single Network Contract Store", () => {
     expect(store.getAddress("BAR")).toEqual(address);
     expect(store.getAddresses()).toEqual([address]);
     expect(() => store.getContract("BAR2" as "BAR")).toThrow();
+
+    expect(store.toObject()).toEqual({
+      abis: {
+        FOO: testAbi,
+        ERC20: ERC20,
+        ERC721: ERC721,
+        ERC1155: ERC1155,
+      },
+      deployments: {
+        BAR: {
+          abiKey: "ERC20",
+          address,
+        },
+      },
+    });
   });
 
   test("it should fail to if a deployment is given with an unknown ABI key", () => {

--- a/src/single-network/single-network-contract-store.ts
+++ b/src/single-network/single-network-contract-store.ts
@@ -135,6 +135,17 @@ export class SingleNetworkContractStore<
   }
 
   /**
+   * Convert the store to an object
+   * @returns The store abis and deployments
+   */
+  public toObject() {
+    return {
+      abis: this.abis,
+      deployments: this.deployments,
+    };
+  }
+
+  /**
    * Get a deployment
    * @param key String key of the deployment
    * @returns The deployment


### PR DESCRIPTION
## Summary

The `toObject` method has been added in the stores in order to export the content of a store into an object