### PR TITLE
feat: allow not defined inputs in constructor

### DIFF
--- a/src/multi-network/dynamic-multi-network-contract-store.ts
+++ b/src/multi-network/dynamic-multi-network-contract-store.ts
@@ -33,7 +33,7 @@ type WithoutDefaultABIs<Opts extends MultiNetworkOptions | undefined> =
 
 type OriginalGlobalABIKey<
   Config extends GenericConfiguration,
-  Opts extends MultiNetworkOptions
+  Opts extends MultiNetworkOptions | undefined
 > = Extract<
   | keyof Config["globalAbis"]
   | (WithoutDefaultABIs<Opts> extends true
@@ -54,7 +54,7 @@ type OriginalDeploymentKey<
 type OriginalABIKey<
   Config extends GenericConfiguration,
   ChainId extends OriginalChainId<Config>,
-  Opts extends MultiNetworkOptions
+  Opts extends MultiNetworkOptions | undefined
 > = Config["networks"][ChainId] extends Network
   ? Extract<
       | keyof Config["networks"][ChainId]["abis"]

--- a/src/multi-network/dynamic-multi-network-contract-store.ts
+++ b/src/multi-network/dynamic-multi-network-contract-store.ts
@@ -349,7 +349,7 @@ export class DynamicContractStore<
    */
   public getGlobalAbi<
     GlobalABIKey extends OriginalGlobalABIKey<OriginalConfig, Opts>
-  >(key: LiteralUnion<GlobalABIKey>) {
+  >(key: LiteralUnion<GlobalABIKey>): ABI {
     if (!this.globalAbis[key]) {
       throw new Error(`Key ${key} is not associated to a global ABI.`);
     }
@@ -365,7 +365,7 @@ export class DynamicContractStore<
   public getAbi<
     ChainId extends OriginalChainId<OriginalConfig>,
     ABIKey extends OriginalABIKey<OriginalConfig, ChainId, Opts>
-  >(chainId: NumericUnion<ChainId>, key: LiteralUnion<ABIKey>) {
+  >(chainId: NumericUnion<ChainId>, key: LiteralUnion<ABIKey>): ABI {
     return this.getStore(chainId).getAbi(key);
   }
 

--- a/src/multi-network/multi-network-contract-store.ts
+++ b/src/multi-network/multi-network-contract-store.ts
@@ -6,8 +6,8 @@ import { Deployment, ABI, Contract } from "../helper-types";
 import { MultiNetworkOptions } from "./common-types";
 
 type Network = {
-  abis: Record<string, ABI>;
-  deployments: Record<string, Deployment>;
+  abis?: Record<string, ABI>;
+  deployments?: Record<string, Deployment>;
 };
 
 type WithoutDefaultABIs<Opts extends MultiNetworkOptions | undefined> =
@@ -19,7 +19,7 @@ type WithoutDefaultABIs<Opts extends MultiNetworkOptions | undefined> =
 
 type GlobalABIKey<
   GlobalABIs extends Record<string, ABI>,
-  Opts extends MultiNetworkOptions
+  Opts extends MultiNetworkOptions | undefined
 > = Extract<
   | keyof GlobalABIs
   | (WithoutDefaultABIs<Opts> extends true
@@ -41,10 +41,10 @@ type DeploymentKey<
   : never;
 
 type ABIKey<
-  GlobalABIs extends Record<string, ABI>,
+  GlobalABIs extends Record<string, ABI> | undefined,
   Networks extends Record<number, Network>,
   ChainId extends AllowedChainId<Networks>,
-  Opts extends MultiNetworkOptions
+  Opts extends MultiNetworkOptions | undefined
 > = Networks[ChainId] extends Network
   ? Extract<
       | keyof Networks[ChainId]["abis"]
@@ -60,7 +60,7 @@ type Configuration<
   GlobalABIs extends Record<string, ABI>,
   Networks extends Record<number, Network>
 > = {
-  globalAbis: GlobalABIs;
+  globalAbis?: GlobalABIs;
   networks: Networks;
 };
 
@@ -68,9 +68,9 @@ type Configuration<
  * Static Contract store for managing ABIs and deployments on multiple networks
  */
 export class ContractStore<
-  GlobalABIs extends Record<string, ABI>,
-  Networks extends Record<number, Network>,
-  Opts extends MultiNetworkOptions
+  GlobalABIs extends Record<string, ABI> = {},
+  Networks extends Record<number, Network> = {},
+  Opts extends MultiNetworkOptions | undefined = undefined
 > {
   private stores;
   private globalAbis;
@@ -95,7 +95,7 @@ export class ContractStore<
         abis["ERC721"] = ERC721;
         abis["ERC1155"] = ERC1155;
       }
-      Object.entries(networkConfig.abis).forEach(([key, abi]) => {
+      Object.entries({ ...networkConfig.abis }).forEach(([key, abi]) => {
         if (abis[key]) {
           throw new Error(
             `An ABI already exists for key ${key} and chain ID ${chainId}`

--- a/src/multi-network/multi-network-contract-store.ts
+++ b/src/multi-network/multi-network-contract-store.ts
@@ -131,7 +131,7 @@ export class ContractStore<
    * @param key String key of the ABI
    * @returns The ABI
    */
-  public getGlobalAbi(key: GlobalABIKey<GlobalABIs, Opts>) {
+  public getGlobalAbi(key: GlobalABIKey<GlobalABIs, Opts>): ABI {
     if (!this.globalAbis[key]) {
       throw new Error(`Key ${key} is not associated to a global ABI.`);
     }
@@ -147,7 +147,7 @@ export class ContractStore<
   public getAbi<ChainId extends AllowedChainId<Networks>>(
     chainId: ChainId,
     key: ABIKey<GlobalABIs, Networks, ChainId, Opts>
-  ) {
+  ): ABI {
     return this.getStore(chainId).getAbi(key as never);
   }
 

--- a/src/single-network/dynamic-single-network-contract-store.ts
+++ b/src/single-network/dynamic-single-network-contract-store.ts
@@ -219,7 +219,7 @@ export class DynamicSingleNetworkContractStore<
    */
   public getAbi<ABIKey extends OriginalABIKey<OriginalConfig, Opts>>(
     key: LiteralUnion<ABIKey>
-  ) {
+  ): ABI {
     const abi = this.abis[key];
     if (!abi) {
       throw new Error(

--- a/src/single-network/single-network-contract-store.ts
+++ b/src/single-network/single-network-contract-store.ts
@@ -32,8 +32,8 @@ type Configuration<
   Opts extends Options | undefined,
   Deployments extends Record<string, Deployment<ABIKey<ABIs, Opts>>>
 > = {
-  abis: ABIs;
-  deployments: Deployments;
+  abis?: ABIs;
+  deployments?: Deployments;
 };
 
 /**

--- a/src/single-network/single-network-contract-store.ts
+++ b/src/single-network/single-network-contract-store.ts
@@ -88,7 +88,7 @@ export class SingleNetworkContractStore<
    * @param key String key of the ABI
    * @returns The ABI
    */
-  public getAbi(key: ABIKey<ABIs, Opts>) {
+  public getAbi(key: ABIKey<ABIs, Opts>): ABI {
     const abi = this.abis[key];
     if (!abi) {
       throw new Error(


### PR DESCRIPTION
## Summary

Constructor arguments are all optional unless for `networks` in multi network contract store